### PR TITLE
Changed gstdbuf to stdbuf

### DIFF
--- a/plugin/vimPy.sh
+++ b/plugin/vimPy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 FILEPATH=$1
 #echo "$FILEPATH" > ~/pyout
-gstdbuf -o0 -e0 python "$FILEPATH" -u > ~/pyout 2>&1
+stdbuf -o0 -e0 python "$FILEPATH" -u > ~/pyout 2>&1
 echo "~~finished running~~" >> ~/pyout


### PR DESCRIPTION
Seems as though Arch Linux does not have gstdbuf, it does however
have stdbuf which works just fine. I'm not sure if this is a bug
on other systems but it is on Arch Linux.
